### PR TITLE
修改提供cell数据源的方法

### DIFF
--- a/KtTableView/KtTableView/KtBaseTableViewCell.h
+++ b/KtTableView/KtTableView/KtBaseTableViewCell.h
@@ -12,7 +12,12 @@
 
 @interface KtBaseTableViewCell : UITableViewCell
 
-@property (nonatomic, retain) id object;
+/**
+ *  子类通过该方法传入Item
+ *
+ *  @param object 用于展示的数据源
+ */
+- (void)setObject:(KtTableViewBaseItem *)object;
 
 + (CGFloat)tableView:(UITableView*)tableView rowHeightForObject:(KtTableViewBaseItem *)object;
 


### PR DESCRIPTION
原来的方案是通过属性的方式更新cell。但是在实际使用中，会产生对外提供model的副作用。所以替换为通过`- (void)setObject:(KtTableViewBaseItem *)object;`来实现更新界面的方法。
