### PR TITLE
监听对象释放。优化log输出

### DIFF
--- a/RunloopAndThread/RunloopAndThread.xcodeproj/project.pbxproj
+++ b/RunloopAndThread/RunloopAndThread.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		9BAA82B11D451A0E00E5B98A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9BAA82AF1D451A0E00E5B98A /* Main.storyboard */; };
 		9BAA82B31D451A0E00E5B98A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9BAA82B21D451A0E00E5B98A /* Assets.xcassets */; };
 		9BAA82B61D451A0E00E5B98A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9BAA82B41D451A0E00E5B98A /* LaunchScreen.storyboard */; };
+		E59118CB1D9B84FE00F25FF6 /* NSObject+DeallocBlock.m in Sources */ = {isa = PBXBuildFile; fileRef = E59118CA1D9B84FE00F25FF6 /* NSObject+DeallocBlock.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,8 @@
 		9BAA82B21D451A0E00E5B98A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9BAA82B51D451A0E00E5B98A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9BAA82B71D451A0E00E5B98A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E59118C91D9B84FE00F25FF6 /* NSObject+DeallocBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+DeallocBlock.h"; sourceTree = "<group>"; };
+		E59118CA1D9B84FE00F25FF6 /* NSObject+DeallocBlock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+DeallocBlock.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -58,6 +61,8 @@
 		9BAA82A51D451A0E00E5B98A /* RunloopAndThread */ = {
 			isa = PBXGroup;
 			children = (
+				E59118C91D9B84FE00F25FF6 /* NSObject+DeallocBlock.h */,
+				E59118CA1D9B84FE00F25FF6 /* NSObject+DeallocBlock.m */,
 				9BAA82A91D451A0E00E5B98A /* AppDelegate.h */,
 				9BAA82AA1D451A0E00E5B98A /* AppDelegate.m */,
 				9BAA82AC1D451A0E00E5B98A /* ViewController.h */,
@@ -110,7 +115,7 @@
 				TargetAttributes = {
 					9BAA82A21D451A0E00E5B98A = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = U2HX3RFD94;
+						DevelopmentTeam = RN42P92PY7;
 					};
 				};
 			};
@@ -150,6 +155,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E59118CB1D9B84FE00F25FF6 /* NSObject+DeallocBlock.m in Sources */,
 				9BAA82AE1D451A0E00E5B98A /* ViewController.m in Sources */,
 				9BAA82AB1D451A0E00E5B98A /* AppDelegate.m in Sources */,
 				9BAA82A81D451A0E00E5B98A /* main.m in Sources */,
@@ -264,6 +270,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = RN42P92PY7;
 				INFOPLIST_FILE = RunloopAndThread/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = baidu.RunloopAndThread;
@@ -275,6 +282,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = RN42P92PY7;
 				INFOPLIST_FILE = RunloopAndThread/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = baidu.RunloopAndThread;
@@ -301,6 +309,7 @@
 				9BAA82BC1D451A0E00E5B98A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/RunloopAndThread/RunloopAndThread/NSObject+DeallocBlock.h
+++ b/RunloopAndThread/RunloopAndThread/NSObject+DeallocBlock.h
@@ -1,0 +1,14 @@
+//
+//  NSObject+DeallocBlock.h
+//  pengpeng
+//
+//  Created by jianwei.chen on 15/9/6.
+//  Copyright (c) 2015年 AsiaInnovations. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSObject (DeallocBlock)
+
+-(void)runAtDealloc:(dispatch_block_t)block;
+@end

--- a/RunloopAndThread/RunloopAndThread/NSObject+DeallocBlock.m
+++ b/RunloopAndThread/RunloopAndThread/NSObject+DeallocBlock.m
@@ -1,0 +1,45 @@
+//
+//  NSObject+DeallocBlock.m
+//  pengpeng
+//
+//  Created by jianwei.chen on 15/9/6.
+//  Copyright (c) 2015年 AsiaInnovations. All rights reserved.
+//
+
+#import "NSObject+DeallocBlock.h"
+#import <objc/message.h>
+
+@interface NBDeallocBlockExecutor : NSObject{
+    dispatch_block_t _block;
+}
+- (id)initWithBlock:(dispatch_block_t)block;
+@end
+
+@implementation NBDeallocBlockExecutor
+- (id)initWithBlock:(dispatch_block_t)aBlock
+{
+    self = [super init];
+    if (self) {
+        _block = [aBlock copy];
+    }
+    return self;
+}
+- (void)dealloc
+{
+    _block ? _block() : nil;
+}
+@end
+
+
+static char *dealloc_key;
+@implementation NSObject (DeallocBlock)
+
+-(void)runAtDealloc:(dispatch_block_t)block
+{
+    if(block){
+        NBDeallocBlockExecutor *executor = [[NBDeallocBlockExecutor alloc] initWithBlock:block];
+        objc_setAssociatedObject(self, &dealloc_key, executor, OBJC_ASSOCIATION_RETAIN);//不要强应用
+    }
+}
+
+@end


### PR DESCRIPTION
通过log分析，得出以下结论，帮我们深入了解线程长活问题
 //总结：test At: xcode8,ios 9.3.4
      //1,当用CFRunLoopRun(),然后调用CFRunLoopStop，此方法是后果会输出current thread，thread dealloc，current thread，thread dealloc ...所以不会用内存问题
        //2,当用 [runLoop run];,然后调用CFRunLoopStop,此方法会current thread，current thread，... 最后输出[NSThread start]: Thread creation failed with error 35.然后app卡住，然后app crash. 内存不会暴增。但是线程无法销毁
        //3,当用 [runLoop runMode:NSRunLoopCommonModes beforeDate:[NSDate distantFuture]];,然后调用CFRunLoopStop,此方法会。[ViewController performSelector:onThread:withObject:waitUntilDone:modes:]: target thread exited while waiting for the perform' crash。是因为 [runLoop runMode:NSRunLoopCommonModes beforeDate:[NSDate distantFuture]]; 无法阻塞线程，所以线程很快执行完run 方法。然后线程exit，导致奔溃（在一个退出的线程，当然这个时候线程没有释放，执行方法奔溃）
