### PR TITLE
修改Header和Library Search Path,解决缺少头文件报错的问题

### DIFF
--- a/CocoaPodsDemo/ShellProject/ShellProject.xcodeproj/project.pbxproj
+++ b/CocoaPodsDemo/ShellProject/ShellProject.xcodeproj/project.pbxproj
@@ -285,9 +285,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				HEADER_SEARCH_PATHS = (
-					"$PROJECT_DIR/../Build/Products/Debug-iphonesimulator/LibOne",
+					"$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/LibOne",
 					"$(inherited)",
-					"$PROJECT_DIR/../Build/Products/Debug-iphonesimulator/LibTwo",
+					"$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/LibTwo",
 				);
 				INFOPLIST_FILE = ShellProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -312,9 +312,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				HEADER_SEARCH_PATHS = (
-					"$PROJECT_DIR/../Build/Products/Debug-iphonesimulator/LibOne",
+					"$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/LibOne",
 					"$(inherited)",
-					"$PROJECT_DIR/../Build/Products/Debug-iphonesimulator/LibTwo",
+					"$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)/LibTwo",
 				);
 				INFOPLIST_FILE = ShellProject/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";


### PR DESCRIPTION
下载下来的代码,编译时候报缺少头文件,因为在给定的路径中找不到Liraryb和头文件.