### PR TITLE
Update GraphicsPerformance-Starter project syntax to Swift 3.2

### DIFF
--- a/GraphicsPerformance-Starter/GraphicsPerformance-Starter.xcodeproj/project.pbxproj
+++ b/GraphicsPerformance-Starter/GraphicsPerformance-Starter.xcodeproj/project.pbxproj
@@ -207,16 +207,16 @@
 				TargetAttributes = {
 					9BEA051B1C50EFAC0075E954 = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = U2HX3RFD94;
+						DevelopmentTeam = FQL8675Q6W;
 					};
 					9BEA05311C50EFAC0075E954 = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = U2HX3RFD94;
+						DevelopmentTeam = FQL8675Q6W;
 						TestTargetID = 9BEA051B1C50EFAC0075E954;
 					};
 					9BEA053C1C50EFAC0075E954 = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = U2HX3RFD94;
+						DevelopmentTeam = FQL8675Q6W;
 						TestTargetID = 9BEA051B1C50EFAC0075E954;
 					};
 				};
@@ -416,10 +416,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = FQL8675Q6W;
 				INFOPLIST_FILE = "GraphicsPerformance-Starter/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "NEU.GraphicsPerformance-Starter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -427,10 +429,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = FQL8675Q6W;
 				INFOPLIST_FILE = "GraphicsPerformance-Starter/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "NEU.GraphicsPerformance-Starter";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -438,6 +442,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = FQL8675Q6W;
 				INFOPLIST_FILE = "GraphicsPerformance-StarterTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "NEU.GraphicsPerformance-StarterTests";
@@ -450,6 +455,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = FQL8675Q6W;
 				INFOPLIST_FILE = "GraphicsPerformance-StarterTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "NEU.GraphicsPerformance-StarterTests";
@@ -461,6 +467,7 @@
 		9BEA054D1C50EFAC0075E954 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = FQL8675Q6W;
 				INFOPLIST_FILE = "GraphicsPerformance-StarterUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "NEU.GraphicsPerformance-StarterUITests";
@@ -473,6 +480,7 @@
 		9BEA054E1C50EFAC0075E954 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = FQL8675Q6W;
 				INFOPLIST_FILE = "GraphicsPerformance-StarterUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "NEU.GraphicsPerformance-StarterUITests";

--- a/GraphicsPerformance-Starter/GraphicsPerformance-Starter.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/GraphicsPerformance-Starter/GraphicsPerformance-Starter.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/GraphicsPerformance-Starter/GraphicsPerformance-Starter/CustomTableCell.swift
+++ b/GraphicsPerformance-Starter/GraphicsPerformance-Starter/CustomTableCell.swift
@@ -9,16 +9,16 @@
 import UIKit
 
 class CustomTableCell: UITableViewCell {
-    let imgView = UIImageView(frame: CGRectMake(10, 10, 180, 180))
-    let label = UILabel(frame: CGRectMake(220, 90, 150, 20))
+    let imgView = UIImageView(frame: CGRect(x: 10, y: 10, width: 180, height: 180))
+    let label = UILabel(frame: CGRect(x: 220, y: 90, width: 150, height: 20))
     
     override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        imgView.layer.shadowColor = UIColor.blackColor().CGColor
+        imgView.layer.shadowColor = UIColor.black.cgColor
         imgView.layer.shadowOpacity = 1
         imgView.layer.shadowRadius = 2
-        imgView.layer.shadowOffset = CGSizeMake(1, 1)
+        imgView.layer.shadowOffset = CGSize(width: 1, height: 1)
         
         label.layer.shouldRasterize = true
         

--- a/GraphicsPerformance-Starter/GraphicsPerformance-Starter/FirstViewController.swift
+++ b/GraphicsPerformance-Starter/GraphicsPerformance-Starter/FirstViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 
 class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-    let table = UITableView(frame: CGRectMake(0, 0, UIScreen.mainScreen().bounds.size.width, UIScreen.mainScreen().bounds.size.height - 49))
+    let table = UITableView(frame: CGRect(x: 0, y:0, width: UIScreen.main.bounds.size.width, height: UIScreen.main.bounds.size.height - 49))
     let imgArray = Array(1...10)
     
     override func viewDidLoad() {
@@ -25,24 +25,25 @@ class FirstViewController: UIViewController, UITableViewDelegate, UITableViewDat
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
+    
 
-    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let identifier = "tableviewcell"
-        var cell = table.dequeueReusableCellWithIdentifier(identifier) as? CustomTableCell
+        var cell = tableView.dequeueReusableCell(withIdentifier: identifier) as? CustomTableCell
         if cell == nil {
-            cell = CustomTableCell(style: .Default, reuseIdentifier: identifier)
-            cell?.selectionStyle = .None
+            cell = CustomTableCell(style: .default, reuseIdentifier: identifier)
+            cell?.selectionStyle = .none
         }
-        cell?.setupContent(String(imgArray[indexPath.row]), text: "This is a label")
-
+        cell?.setupContent(imgName: String(imgArray[indexPath.row]), text: "This is a label")
+        
         return cell!
     }
     
-    func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 200
     }
     
-    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 10
     }
 }


### PR DESCRIPTION
Because the brand new Xcode 9.0 cannot compile Swift 2.x project, so I just manual finish the migration of the GraphicsPerformance-Starter project.